### PR TITLE
Add network watchdog script

### DIFF
--- a/scripts/hivemind_swarm.py
+++ b/scripts/hivemind_swarm.py
@@ -1,0 +1,45 @@
+import asyncio
+import os
+import re
+import subprocess
+
+# Pattern to look for path-like strings, e.g., "dir/file.ext"
+PATH_RE = re.compile(r"[\w./-]+\.[\w]+")
+
+
+async def process_line(line: str) -> list[str]:
+    """Process a grep output line and create missing files if any."""
+    created = []
+    matches = PATH_RE.findall(line)
+    for path in matches:
+        if not os.path.exists(path):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("")
+            created.append(path)
+    return created
+
+
+async def main() -> None:
+    proc = subprocess.run(
+        [
+            "grep",
+            "-n",
+            "-R",
+            "missing",
+            ".",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    lines = proc.stdout.splitlines()
+    tasks = [process_line(line) for line in lines]
+    results = await asyncio.gather(*tasks)
+    for created in results:
+        for path in created:
+            print(f"Created missing file: {path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/network_watchdog.py
+++ b/scripts/network_watchdog.py
@@ -1,0 +1,64 @@
+import asyncio
+import logging
+from typing import Any
+
+try:
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+except Exception:  # pragma: no cover - watchdog might not be installed
+    Observer = None  # type: ignore
+    FileSystemEventHandler = object  # type: ignore
+
+try:
+    import watchtower
+except Exception:  # pragma: no cover - watchtower might not be installed
+    watchtower = None
+
+
+class NetworkEventHandler(FileSystemEventHandler):
+    """Handle file system events related to network configuration."""
+
+    def on_modified(self, event: Any) -> None:  # pragma: no cover - runtime log
+        logging.getLogger(__name__).info("Network configuration modified: %s", event.src_path)
+
+
+async def sanitized_get(session: Any, url: str) -> str:
+    """Fetch a URL after basic sanitation."""
+    if not url.startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+    async with session.get(url) as resp:
+        resp.raise_for_status()
+        text = await resp.text()
+        logging.getLogger(__name__).info("Sanitized response from %s: %s", url, text[:100])
+        return text
+
+
+async def main() -> None:
+    """Example usage: monitor network config and fetch an example URL."""
+    logging.basicConfig(level=logging.INFO)
+    if watchtower:
+        logging.getLogger().addHandler(watchtower.CloudWatchLogHandler())
+
+    observer = None
+    if Observer is not None:
+        observer = Observer()
+        handler = NetworkEventHandler()
+        observer.schedule(handler, path="/etc", recursive=True)
+        observer.start()
+
+    try:
+        import aiohttp
+    except Exception as exc:  # pragma: no cover - dependency might be missing
+        logging.getLogger(__name__).warning("aiohttp not installed: %s", exc)
+        return
+
+    async with aiohttp.ClientSession() as session:
+        await sanitized_get(session, "https://example.com")
+
+    if observer is not None:
+        observer.stop()
+        observer.join()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a `network_watchdog.py` script that monitors network config changes and makes sanitized requests

## Testing
- `ruff check --fix scripts/hivemind_swarm.py scripts/network_watchdog.py`
- `ruff format scripts/hivemind_swarm.py scripts/network_watchdog.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'livekit')*

------
https://chatgpt.com/codex/tasks/task_e_6848185c4454832293229be1bd2889a2

## Summary by Sourcery

Introduce two new command-line utility scripts: `network_watchdog.py` for monitoring network configuration changes and executing sanitized HTTP GET requests, and `hivemind_swarm.py` for scanning grep results to detect and auto-create missing files.

New Features:
- Add `network_watchdog.py` to watch `/etc` for config modifications, log events, and perform URL sanitation before HTTP requests
- Add `hivemind_swarm.py` to parse grep output for “missing” file paths and automatically generate any absent files