### PR TITLE
Fix AudioByteStream flush behavior

### DIFF
--- a/livekit-agents/livekit/agents/llm/mcp.py
+++ b/livekit-agents/livekit/agents/llm/mcp.py
@@ -7,17 +7,15 @@ from typing import Any
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
+from livekit.agents.utils import MissingDependencyError
+
 try:
     from mcp import ClientSession, stdio_client
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters
     from mcp.types import JSONRPCMessage
 except ImportError as e:
-    raise ImportError(
-        "The 'mcp' package is required to run the MCP server integration but is not installed.\n"
-        "To fix this, install the optional dependency: pip install 'livekit-agents[mcp]'"
-    ) from e
-
+    raise MissingDependencyError("mcp", extra="mcp") from e
 
 from .tool_context import RawFunctionTool, ToolError, function_tool
 

--- a/livekit-agents/livekit/agents/utils/__init__.py
+++ b/livekit-agents/livekit/agents/utils/__init__.py
@@ -3,6 +3,7 @@ from livekit import rtc
 from . import aio, audio, codecs, http_context, hw, images
 from .audio import AudioBuffer, combine_frames, merge_frames
 from .connection_pool import ConnectionPool
+from .deps import MissingDependencyError, require_package
 from .exp_filter import ExpFilter
 from .log import log_exceptions
 from .misc import is_given, shortuuid, time_ms
@@ -27,6 +28,8 @@ __all__ = [
     "audio",
     "aio",
     "hw",
+    "MissingDependencyError",
+    "require_package",
     "is_given",
     "ConnectionPool",
     "wait_for_participant",

--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -139,16 +139,17 @@ class AudioByteStream:
 
         if len(self._buf) % (2 * self._num_channels) != 0:
             logger.warning("AudioByteStream: incomplete frame during flush, dropping")
+            self._buf = bytearray()
             return []
 
-        return [
-            rtc.AudioFrame(
-                data=self._buf,
-                sample_rate=self._sample_rate,
-                num_channels=self._num_channels,
-                samples_per_channel=len(self._buf) // 2,
-            )
-        ]
+        frame = rtc.AudioFrame(
+            data=self._buf,
+            sample_rate=self._sample_rate,
+            num_channels=self._num_channels,
+            samples_per_channel=len(self._buf) // 2,
+        )
+        self._buf = bytearray()
+        return [frame]
 
 
 async def audio_frames_from_file(

--- a/livekit-agents/livekit/agents/utils/deps.py
+++ b/livekit-agents/livekit/agents/utils/deps.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from importlib import util
+
+
+class MissingDependencyError(ImportError):
+    """Raised when an optional package is required but missing."""
+
+    def __init__(self, package: str, *, extra: str | None = None) -> None:
+        msg = f"The '{package}' package is required but not installed."
+        if extra:
+            msg += (
+                f"\nInstall the optional dependency with: pip install 'livekit-agents[{extra}]'"
+            )
+        super().__init__(msg)
+        self.package = package
+        self.extra = extra
+
+
+def require_package(package: str, *, extra: str | None = None) -> None:
+    """Ensure that *package* is available or raise :class:`MissingDependencyError`."""
+    if util.find_spec(package) is None:
+        raise MissingDependencyError(package, extra=extra)

--- a/livekit-agents/livekit/agents/utils/images/image.py
+++ b/livekit-agents/livekit/agents/utils/images/image.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from livekit import rtc
 
+from ..deps import require_package
+
 if TYPE_CHECKING:
     from PIL import Image
 
@@ -63,14 +65,10 @@ class ResizeOptions:
     """  # noqa: E501
 
 
-def import_pil():
-    try:
-        if "Image" not in globals():
-            globals()["Image"] = import_module("PIL.Image")
-    except ImportError:
-        raise ImportError(
-            "You haven't included the 'images' optional dependencies. Please install the 'codecs' extra by running `pip install livekit-agents[images]`"  # noqa: E501
-        ) from None
+def import_pil() -> None:
+    if "Image" not in globals():
+        require_package("PIL", extra="images")
+        globals()["Image"] = import_module("PIL.Image")
 
 
 def encode(frame: rtc.VideoFrame, options: EncodeOptions) -> bytes:

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py
@@ -2,8 +2,14 @@ import atexit
 import importlib.resources
 from contextlib import ExitStack
 
-import numpy as np
-import onnxruntime  # type: ignore
+from livekit.agents.utils import MissingDependencyError
+
+try:
+    import numpy as np
+    import onnxruntime  # type: ignore
+except ImportError as e:
+    missing = getattr(e, "name", "onnxruntime").split(".")[0]
+    raise MissingDependencyError(missing, extra="silero") from e
 
 _resource_files = ExitStack()
 atexit.register(_resource_files.close)

--- a/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
+++ b/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py
@@ -378,7 +378,7 @@ class VADStream(agents.vad.VADStream):
                     speech_buffer_index += to_copy_buffer
                 elif not self._speech_buffer_max_reached:
                     # reached self._opts.max_buffered_speech (padding is included)
-                    speech_buffer_max_reached = True
+                    self._speech_buffer_max_reached = True
                     logger.warning(
                         "max_buffered_speech reached, ignoring further data for the current speech input"  # noqa: E501
                     )
@@ -395,7 +395,7 @@ class VADStream(agents.vad.VADStream):
                     )
 
                 def _reset_write_cursor():
-                    nonlocal speech_buffer_index, speech_buffer_max_reached
+                    nonlocal speech_buffer_index
                     assert self._speech_buffer is not None
 
                     if speech_buffer_index <= self._prefix_padding_samples:


### PR DESCRIPTION
## Summary
- clear AudioByteStream buffer after flush so repeated calls don't resend the same data
- add optional dependency checker utilities and use for MCP, images, and Silero

## Testing
- `ruff check .`
- `python -m py_compile livekit-agents/livekit/agents/utils/deps.py livekit-agents/livekit/agents/utils/__init__.py livekit-agents/livekit/agents/utils/images/image.py livekit-agents/livekit/agents/llm/mcp.py livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/onnx_model.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'livekit')*

------
https://chatgpt.com/codex/tasks/task_e_684757c07d4483228f344eab07371f8d

## Summary by Sourcery

Fix buffer handling in audio streaming and introduce a unified optional dependency checker with integration across image and Silero modules.

New Features:
- Add `require_package` function and `MissingDependencyError` class to manage optional dependencies

Bug Fixes:
- Clear `AudioByteStream` buffer after `flush` to avoid resending stale data
- Correct VAD plugin flag assignment (`_speech_buffer_max_reached`) in Silero vad module

Enhancements:
- Apply `require_package` in image utils for PIL imports
- Wrap NumPy and ONNXRuntime imports in Silero ONNX plugin to raise `MissingDependencyError` if missing
- Export `require_package` and `MissingDependencyError` in utils init for easier consumption