### PR TITLE
Add search fix agent workflow

### DIFF
--- a/.github/workflows/search-fix-agent.yml
+++ b/.github/workflows/search-fix-agent.yml
@@ -1,0 +1,20 @@
+name: Search Fix Agent
+
+on:
+  workflow_dispatch:
+
+jobs:
+  search-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install ruff pytest
+          pip install -e livekit-agents
+      - name: Run search and fix agent
+        run: python scripts/search_fix_agent.py

--- a/examples/other/search_fix_agent/README.md
+++ b/examples/other/search_fix_agent/README.md
@@ -1,0 +1,23 @@
+# Search and Fix Agent Workflow
+
+This example demonstrates a simple workflow that repeatedly runs tests and
+applies automated fixes until no errors remain.
+
+1. `ruff check --fix` is executed to detect and fix style issues.
+2. Formatting is applied using `ruff format`.
+3. `pytest` runs the test suite.
+4. If tests fail, the process repeats up to five times.
+
+Before running the script, ensure the local package is installed in editable
+mode so imports like `livekit` resolve correctly:
+
+```bash
+pip install -e livekit-agents
+```
+
+The script installs the package automatically, but doing it ahead of time can
+avoid noisy log output.
+
+The logic is implemented in `scripts/search_fix_agent.py` and can be triggered
+manually via the `Search Fix Agent` GitHub Actions workflow. The agent outputs
+lively messages whenever tests fail to keep the process cheerful.

--- a/scripts/search_fix_agent.py
+++ b/scripts/search_fix_agent.py
@@ -1,0 +1,48 @@
+import logging
+import subprocess
+import sys
+
+MAX_ITERATIONS = 5
+
+
+def install_package() -> None:
+    """Ensure the local package is installed in editable mode."""
+    run_command([sys.executable, "-m", "pip", "install", "-e", "livekit-agents"])
+
+
+def run_command(cmd: list[str]) -> bool:
+    """Run a command and return True if it succeeds."""
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.stdout:
+        logging.info(proc.stdout)
+    if proc.returncode != 0:
+        if proc.stderr:
+            logging.error(proc.stderr)
+    return proc.returncode == 0
+
+
+def search_and_fix() -> bool:
+    """Recursively test, fix, and retest until no errors remain."""
+    install_package()
+    for attempt in range(1, MAX_ITERATIONS + 1):
+        logging.info("Iteration %s", attempt)
+        run_command(["ruff", "check", "--fix", "."])
+        run_command(["ruff", "format", "."])
+        if run_command(["pytest"]):
+            logging.info("All tests passed")
+            return True
+        logging.info("Tests failed, let's give it another go!")
+    logging.error(
+        "Could not fix all errors after %s lively attempts", MAX_ITERATIONS
+    )
+    return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    success = search_and_fix()
+    if success:
+        logging.info("Finished with flying colors!")
+    else:
+        logging.error("Giving up after repeated attempts :(")
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run a search-and-fix agent
- implement `search_fix_agent.py` script
- document how the workflow operates
- add automatic editable install and lively test messages

## Testing
- `ruff check scripts/search_fix_agent.py`
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'livekit')*

------
https://chatgpt.com/codex/tasks/task_e_685177f3a5488322ac0abb472de9ec5d