### PR TITLE
Add zero trust installer script

### DIFF
--- a/scripts/zero_trust_installer.py
+++ b/scripts/zero_trust_installer.py
@@ -1,0 +1,69 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+DEFAULT_ALLOWED_HOSTS = {"pypi.org", "files.pythonhosted.org"}
+
+
+def _is_trusted_host(index_url: str, allowed_hosts: set[str]) -> bool:
+    host = urlparse(index_url).hostname
+    return host in allowed_hosts
+
+
+def _validate_requirements(requirements_path: Path) -> None:
+    for lineno, line in enumerate(requirements_path.read_text().splitlines(), 1):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "--hash=" not in line:
+            raise ValueError(f"Line {lineno} missing --hash: {line}")
+
+
+def install_requirements(
+    requirements: Path, index_url: str, allowed_hosts: set[str] | None = None
+) -> None:
+    allowed_hosts = allowed_hosts or DEFAULT_ALLOWED_HOSTS
+    if not _is_trusted_host(index_url, allowed_hosts):
+        raise ValueError(
+            f"index host '{urlparse(index_url).hostname}' not in allowed hosts {allowed_hosts}"
+        )
+
+    _validate_requirements(requirements)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--require-hashes",
+        "--no-deps",
+        "--index-url",
+        index_url,
+        "-r",
+        str(requirements),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Install dependencies from trusted sources")
+    parser.add_argument("--requirements", type=Path, default=Path("requirements.txt"))
+    parser.add_argument("--index-url", default="https://pypi.org/simple")
+    parser.add_argument(
+        "--allow-host",
+        action="append",
+        dest="allow_hosts",
+        default=[],
+        help="Additional allowed hosts",
+    )
+    args = parser.parse_args()
+
+    allowed_hosts = DEFAULT_ALLOWED_HOSTS | set(args.allow_hosts)
+    install_requirements(args.requirements, args.index_url, allowed_hosts)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_zero_trust_installer.py
+++ b/tests/test_zero_trust_installer.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.zero_trust_installer import _is_trusted_host, _validate_requirements
+
+
+def test_is_trusted_host() -> None:
+    assert _is_trusted_host("https://pypi.org/simple", {"pypi.org"})
+    assert not _is_trusted_host("https://evil.com", {"pypi.org"})
+
+
+def test_validate_requirements(tmp_path: Path) -> None:
+    req = tmp_path / "req.txt"
+    req.write_text("package==1.0 --hash=sha256:deadbeef\n")
+    _validate_requirements(req)
+
+    req.write_text("package==1.0\n")
+    with pytest.raises(ValueError):
+        _validate_requirements(req)


### PR DESCRIPTION
## Summary
- add script to install dependencies from trusted hosts only
- include basic tests for URL and requirements validation

## Testing
- `pytest --noconftest tests/test_zero_trust_installer.py -q`
- `pip install -e .` *(fails: 403 Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687b6301c5b4832289a4e641deca7565

## Summary by Sourcery

Add a zero-trust installer script that enforces installation only from trusted package indexes and requires hash-verified requirements, along with basic tests for host validation and requirement hash enforcement.

New Features:
- Add zero_trust_installer script to install dependencies only from allowed hosts with hash-based verification
- Support extending allowed hosts via command-line flags

Tests:
- Add tests for _is_trusted_host to ensure only specified hosts are trusted
- Add tests for _validate_requirements to enforce --hash presence in requirement lines