### PR TITLE
Refactor hivemind swarm script to use ripgrep

### DIFF
--- a/scripts/hivemind_swarm.py
+++ b/scripts/hivemind_swarm.py
@@ -7,25 +7,15 @@ import subprocess
 PATH_RE = re.compile(r"[\w./-]+\.[\w]+")
 
 
-async def process_line(line: str) -> list[str]:
-    """Process a grep output line and create missing files if any."""
-    created = []
-    matches = PATH_RE.findall(line)
-    for path in matches:
-        if not os.path.exists(path):
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, "w", encoding="utf-8") as f:
-                f.write("")
-            created.append(path)
-    return created
-
-
-async def main() -> None:
+def find_missing_lines() -> list[str]:
+    """Search the repository for lines containing the token `missing`."""
     proc = subprocess.run(
         [
             "rg",
             "--line-number",
             "--no-heading",
+            "--color",
+            "never",
             "missing",
             ".",
         ],
@@ -33,7 +23,26 @@ async def main() -> None:
         text=True,
         check=False,
     )
-    lines = proc.stdout.splitlines()
+    return proc.stdout.splitlines()
+
+
+async def process_line(line: str) -> list[str]:
+    """Process a ripgrep output line and create missing files if any."""
+    created = []
+    matches = PATH_RE.findall(line)
+    for path in matches:
+        if not os.path.exists(path):
+            directory = os.path.dirname(path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("")
+            created.append(path)
+    return created
+
+
+async def main() -> None:
+    lines = find_missing_lines()
     tasks = [process_line(line) for line in lines]
     results = await asyncio.gather(*tasks)
     for created in results:

--- a/scripts/hivemind_swarm.py
+++ b/scripts/hivemind_swarm.py
@@ -23,9 +23,9 @@ async def process_line(line: str) -> list[str]:
 async def main() -> None:
     proc = subprocess.run(
         [
-            "grep",
-            "-n",
-            "-R",
+            "rg",
+            "--line-number",
+            "--no-heading",
             "missing",
             ".",
         ],


### PR DESCRIPTION
## Summary
- update the hivemind swarm script to use ripgrep (rg) for searching

## Testing
- python -m compileall scripts/hivemind_swarm.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d8f9ce0e188322b7e8cee1fabe84fd)

## Summary by Sourcery

Enhancements:
- Switch the hivemind swarm script from grep to ripgrep with flags adjusted to preserve line number output without headings.